### PR TITLE
Fixes for updated TypeScript default starter kit name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Updated
+
+- Fixes for updated TypeScript default starter kit name
+
 ## [0.1.1]
 
 ### Fixed

--- a/src/cli/fastlyStarterKits.ts
+++ b/src/cli/fastlyStarterKits.ts
@@ -18,7 +18,7 @@ export const KNOWN_STARTER_KITS: Record<Language, Repository[]> = {
   ],
   'typescript': [
     {
-      fullName: 'fastly/compute-starter-kit-typescript',
+      fullName: 'fastly/compute-starter-kit-typescript-default',
       description: 'A simple Fastly starter kit for Typescript',
     },
   ],


### PR DESCRIPTION
The GitHub URL for the TypeScript default starter kit has recently been renamed from https://github.com/fastly/compute-starter-kit-typescript to https://github.com/fastly/compute-starter-kit-typescript-default to make starter kit names consistent between languages.

GitHub automatically provides 301 redirects so breakages will not occur (notably, I have seen that the existing version of this package and CLI are able to initialize a new project following the redirect), but this PR updates these references.
